### PR TITLE
아카이브 등록 with. 사진 업로드

### DIFF
--- a/kilometer-backend-api/src/main/java/com/kilometer/backend/controller/ArchiveController.java
+++ b/kilometer-backend-api/src/main/java/com/kilometer/backend/controller/ArchiveController.java
@@ -27,33 +27,34 @@ public class ArchiveController {
     @GetMapping(ApiUrlUtils.ARCHIVE_ITEM)
     @ApiOperation(value = "전시글에서 아카이브 조회")
     public ItemDetailResponse<ArchiveResponse> archives(
-            @ApiParam(value = "조회할 전시글 ID", required = true) @PathVariable Long itemId,
-            @ApiParam(value = "아카이브 페이지 정보", required = true) RequestPagingStatus requestPagingStatus,
-            @ApiParam(value = "아카이브 정렬 기준", required = true, defaultValue = "MODIFY_DESC : 수정일 기준 정렬")
-            @RequestParam(defaultValue = "MODIFY_DESC") ArchiveSortType sortType) {
-        ArchiveResponse response = archiveService.findAllByItemId(itemId, requestPagingStatus, sortType);
+        @ApiParam(value = "조회할 전시글 ID", required = true) @PathVariable Long itemId,
+        @ApiParam(value = "아카이브 페이지 정보", required = true) RequestPagingStatus requestPagingStatus,
+        @ApiParam(value = "아카이브 정렬 기준", required = true, defaultValue = "MODIFY_DESC : 수정일 기준 정렬")
+        @RequestParam(defaultValue = "MODIFY_DESC") ArchiveSortType sortType) {
+        ArchiveResponse response = archiveService.findAllByItemId(itemId, requestPagingStatus,
+            sortType);
         return ItemDetailResponse.<ArchiveResponse>builder()
-                .title(ARCHIVE_TITLE)
-                .contents(response)
-                .build();
+            .title(ARCHIVE_TITLE)
+            .contents(response)
+            .build();
     }
 
     @PostMapping
     public ArchiveInfo saveArchive(
-            @ApiParam(value = "등록할 아카이브 데이터", required = true) @RequestBody ArchiveRequest request) {
+        @ApiParam(value = "등록할 아카이브 데이터", required = true) @RequestBody ArchiveRequest request) {
         long userId = getLoginUserId();
         return archiveService.save(userId, request);
     }
 
     @GetMapping(ApiUrlUtils.ARCHIVE_MY)
     public ItemDetailResponse<ArchiveResponse> myArchives(
-            @ApiParam(value = "아카이브 페이지 정보", required = true) RequestPagingStatus requestPagingStatus) {
+        @ApiParam(value = "아카이브 페이지 정보", required = true) RequestPagingStatus requestPagingStatus) {
         Long userId = getLoginUserId();
         ArchiveResponse response = archiveService.findAllByUserId(userId, requestPagingStatus);
         return ItemDetailResponse.<ArchiveResponse>builder()
-                .title(MY_ARCHIVE_TITLE)
-                .contents(response)
-                .build();
+            .title(MY_ARCHIVE_TITLE)
+            .contents(response)
+            .build();
     }
 
 

--- a/kilometer-backend-api/src/main/java/com/kilometer/backend/controller/ImageController.java
+++ b/kilometer-backend-api/src/main/java/com/kilometer/backend/controller/ImageController.java
@@ -1,0 +1,25 @@
+package com.kilometer.backend.controller;
+
+import com.kilometer.domain.image.ImageService;
+import com.kilometer.domain.util.ApiUrlUtils;
+import io.swagger.annotations.ApiOperation;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(ApiUrlUtils.IMAGE_ROOT)
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping
+    @ApiOperation(value = "이미지 등록 API")
+    public String upload(MultipartFile file) throws IOException {
+        return imageService.upload(file);
+    }
+}

--- a/kilometer-backend-api/src/main/resources/application.yml
+++ b/kilometer-backend-api/src/main/resources/application.yml
@@ -57,3 +57,15 @@ logging:
           descriptor:
             sql: trace
   config: classpath:log4j2.xml
+
+cloud:
+  aws:
+    s3:
+      bucket: kilometer-image
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    credentials:
+      accessKey: ${s3.accessKey}
+      secretKey: ${s3.secretKey}

--- a/kilometer-backend-domain/build.gradle
+++ b/kilometer-backend-domain/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     )
     implementation "org.flywaydb:flyway-mysql:8.5.10"
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    implementation 'org.springframework:spring-web:5.3.9'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 bootRun.enabled = false

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchivePhotoRepository.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchivePhotoRepository.java
@@ -1,0 +1,8 @@
+package com.kilometer.domain.archive;
+
+import com.kilometer.domain.archive.entity.ArchivePhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArchivePhotoRepository extends JpaRepository<ArchivePhoto, Long> {
+
+}

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepository.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepository.java
@@ -1,12 +1,11 @@
 package com.kilometer.domain.archive;
 
+import com.kilometer.domain.archive.entity.Archive;
 import com.kilometer.domain.item.ItemEntity;
 import com.kilometer.domain.user.User;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface ArchiveRepository extends JpaRepository<Archive, Long>, ArchiveRepositoryCustom {
     List<Archive> findAllByItemAndUser(ItemEntity item, User user);

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepositoryCustomImpl.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepositoryCustomImpl.java
@@ -1,21 +1,18 @@
 package com.kilometer.domain.archive;
 
 import com.kilometer.domain.archive.dto.ArchiveSortType;
+import com.kilometer.domain.archive.entity.QArchive;
+import com.kilometer.domain.archive.entity.QVisitedPlace;
 import com.kilometer.domain.archive.queryDto.ArchiveSelectResult;
 import com.kilometer.domain.user.QUser;
-import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import javax.persistence.EntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-
-import javax.persistence.EntityManager;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class ArchiveRepositoryCustomImpl implements ArchiveRepositoryCustom {
 

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveService.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveService.java
@@ -4,13 +4,15 @@ import com.kilometer.domain.archive.dto.ArchiveInfo;
 import com.kilometer.domain.archive.dto.ArchiveResponse;
 import com.kilometer.domain.archive.dto.ArchiveSortType;
 import com.kilometer.domain.archive.dto.PlaceInfo;
+import com.kilometer.domain.archive.entity.Archive;
+import com.kilometer.domain.archive.entity.ArchivePhoto;
+import com.kilometer.domain.archive.entity.VisitedPlace;
 import com.kilometer.domain.archive.queryDto.ArchiveSelectResult;
 import com.kilometer.domain.archive.request.ArchiveRequest;
 import com.kilometer.domain.item.ItemEntity;
 import com.kilometer.domain.item.ItemRepository;
 import com.kilometer.domain.paging.PagingStatusService;
 import com.kilometer.domain.paging.RequestPagingStatus;
-import com.kilometer.domain.paging.ResponsePagingStatus;
 import com.kilometer.domain.user.User;
 import com.kilometer.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +23,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,61 +32,74 @@ public class ArchiveService {
     private final UserRepository userRepository;
     private final ItemRepository itemRepository;
     private final ArchiveRepository archiveRepository;
+    private final ArchivePhotoRepository archivePhotoRepository;
     private final PagingStatusService pagingStatusService;
 
     public ArchiveInfo save(Long userId, ArchiveRequest archiveRequest) {
         Preconditions.notNull(archiveRequest.getComment(),
-                "Comment must not be null");
-        Preconditions.condition((archiveRequest.getStarRating() > 0 && archiveRequest.getStarRating() <= 5),
-                "별점은 1이상 5이하의 숫자여야 합니다. now : " + archiveRequest.getStarRating());
+            "Comment must not be null");
+        Preconditions.condition(
+            (archiveRequest.getStarRating() > 0 && archiveRequest.getStarRating() <= 5),
+            "별점은 1이상 5이하의 숫자여야 합니다. now : " + archiveRequest.getStarRating());
         Preconditions.notNull(archiveRequest.getPhotoUrls(),
-                "Photo urls must not be null");
+            "Photo urls must not be null");
         Preconditions.notNull(archiveRequest.getPlaceInfos(),
-                "Place infos must not be null");
+            "Place infos must not be null");
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 없습니다. id = " + userId));
+            .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 없습니다. id = " + userId));
 
         ItemEntity item = itemRepository.findById(archiveRequest.getItemId())
-                .orElseThrow(() -> new IllegalArgumentException("Item does not exists 없습니다. id = " + archiveRequest.getItemId()));
+            .orElseThrow(() -> new IllegalArgumentException(
+                "Item does not exists 없습니다. id = " + archiveRequest.getItemId()));
 
         List<Archive> findedArchive = archiveRepository.findAllByItemAndUser(item, user);
 
-        if (!findedArchive.isEmpty())
+        if (!findedArchive.isEmpty()) {
             throw new IllegalArgumentException("이미 Archive가 존재합니다. id : " + findedArchive.get(0));
+        }
 
         List<VisitedPlace> places = new ArrayList<>();
         for (PlaceInfo info : archiveRequest.getPlaceInfos()) {
             places.add(VisitedPlace.builder()
-                    .placeType(PlaceType.valueOf(info.getPlaceType()))
-                    .placeName(info.getName())
-                    .address(info.getAddress())
-                    .roadAddress(info.getRoadAddress())
-                    .build());
+                .placeType(PlaceType.valueOf(info.getPlaceType()))
+                .placeName(info.getName())
+                .address(info.getAddress())
+                .roadAddress(info.getRoadAddress())
+                .build());
         }
 
+        List<ArchivePhoto> photos = new ArrayList<>();
+        archiveRequest.getPhotoUrls().forEach(url -> {
+            ArchivePhoto photo = ArchivePhoto.builder().imageUrl(url).build();
+            photos.add(photo);
+        });
+
         Archive archive = Archive.builder()
-                .comment(archiveRequest.getComment())
-                .starRating(archiveRequest.getStarRating())
-                .isVisibleAtItem(archiveRequest.isVisibleAtItem())
-                .user(user)
-                .item(item)
-                .build();
+            .comment(archiveRequest.getComment())
+            .starRating(archiveRequest.getStarRating())
+            .isVisibleAtItem(archiveRequest.isVisibleAtItem())
+            .user(user)
+            .item(item)
+            .build();
 
         archive.setVisitedPlaces(places);
+        archive.setPhotos(photos);
 
         archiveRepository.save(archive);
 
         return archive.makeInfo();
     }
 
-    public ArchiveResponse findAllByItemId(Long itemId, RequestPagingStatus requestPagingStatus, ArchiveSortType sortType) {
+    public ArchiveResponse findAllByItemId(Long itemId, RequestPagingStatus requestPagingStatus,
+        ArchiveSortType sortType) {
         Preconditions.notNull(itemId, "id must not be null");
         Preconditions.notNull(requestPagingStatus, "page value must not be null");
         Preconditions.notNull(sortType, "sort type value must not be null");
 
         Pageable pageable = pagingStatusService.makePageable(requestPagingStatus, sortType);
-        Page<ArchiveSelectResult> items = archiveRepository.findAllByItemId(pageable, sortType, itemId);
+        Page<ArchiveSelectResult> items = archiveRepository.findAllByItemId(pageable, sortType,
+            itemId);
 
         return convertingItemArchive(items, getStarRatingAvgByItemId(itemId));
     }
@@ -94,23 +108,25 @@ public class ArchiveService {
         Preconditions.notNull(userId, "id must not be null");
         Preconditions.notNull(requestPagingStatus, "page value must not be null");
 
-
         return ArchiveResponse.builder().build();
     }
 
-    private ArchiveResponse convertingItemArchive(Page<ArchiveSelectResult> archiveSelectResults, Double avgStarRating) {
-        List<ArchiveInfo> infos = archiveSelectResults.stream().map(ArchiveSelectResult::convert).collect(Collectors.toList());
+    private ArchiveResponse convertingItemArchive(Page<ArchiveSelectResult> archiveSelectResults,
+        Double avgStarRating) {
+        List<ArchiveInfo> infos = archiveSelectResults.stream().map(ArchiveSelectResult::convert)
+            .collect(Collectors.toList());
         return ArchiveResponse.builder()
-                .responsePagingStatus(pagingStatusService.convert(archiveSelectResults, null))
-                .avgStarRating(avgStarRating)
-                .archives(infos)
-                .build();
+            .responsePagingStatus(pagingStatusService.convert(archiveSelectResults, null))
+            .avgStarRating(avgStarRating)
+            .archives(infos)
+            .build();
     }
 
     private Double getStarRatingAvgByItemId(Long itemId) {
         Double result = archiveRepository.avgStarRatingByItemId(itemId);
-        if (result != null)
+        if (result != null) {
             result = Math.round(result * 10) / 10.0;
+        }
         return result;
     }
 

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/dto/PlaceInfo.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/dto/PlaceInfo.java
@@ -1,6 +1,6 @@
 package com.kilometer.domain.archive.dto;
 
-import com.kilometer.domain.archive.VisitedPlace;
+import com.kilometer.domain.archive.entity.VisitedPlace;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,6 +9,7 @@ import lombok.Data;
 @Builder
 @AllArgsConstructor
 public class PlaceInfo {
+
     private String placeType;
     private String name;
     private String address;
@@ -16,10 +17,10 @@ public class PlaceInfo {
 
     public static PlaceInfo makePlaceInfo(VisitedPlace visitedPlace) {
         return PlaceInfo.builder()
-                .placeType(String.valueOf(visitedPlace.getPlaceType()))
-                .name(visitedPlace.getPlaceName())
-                .address(visitedPlace.getAddress())
-                .roadAddress(visitedPlace.getRoadAddress())
-                .build();
+            .placeType(String.valueOf(visitedPlace.getPlaceType()))
+            .name(visitedPlace.getPlaceName())
+            .address(visitedPlace.getAddress())
+            .roadAddress(visitedPlace.getRoadAddress())
+            .build();
     }
 }

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/entity/Archive.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/entity/Archive.java
@@ -1,5 +1,6 @@
-package com.kilometer.domain.archive;
+package com.kilometer.domain.archive.entity;
 
+import com.kilometer.domain.archive.PlaceType;
 import com.kilometer.domain.archive.dto.ArchiveInfo;
 import com.kilometer.domain.item.ItemEntity;
 import com.kilometer.domain.user.User;
@@ -65,6 +66,9 @@ public class Archive {
     @Builder.Default
     private List<VisitedPlace> visitedPlaces = List.of();
 
+    @OneToMany(mappedBy = "archive", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<ArchivePhoto> archivePhotos = List.of();
 
     public ArchiveInfo makeInfo() {
         String food = "";
@@ -97,4 +101,8 @@ public class Archive {
         this.visitedPlaces.forEach(place -> place.setArchive(this));
     }
 
+    public void setPhotos(List<ArchivePhoto> photos) {
+        this.archivePhotos = photos;
+        this.archivePhotos.forEach(photo -> photo.setArchive(this));
+    }
 }

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/entity/ArchivePhoto.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/entity/ArchivePhoto.java
@@ -1,0 +1,37 @@
+package com.kilometer.domain.archive.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "archive_photo")
+public class ArchivePhoto {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "archiveId")
+    private Archive archive;
+
+    public void setArchive(Archive archive) {
+        this.archive = archive;
+    }
+}

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/entity/VisitedPlace.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/entity/VisitedPlace.java
@@ -1,5 +1,6 @@
-package com.kilometer.domain.archive;
+package com.kilometer.domain.archive.entity;
 
+import com.kilometer.domain.archive.PlaceType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -22,7 +23,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "visited_place")
 public class VisitedPlace {
 
-    @Id @GeneratedValue
+    @Id
+    @GeneratedValue
     private Long id;
 
     @ManyToOne

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/queryDto/ArchiveSelectResult.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/queryDto/ArchiveSelectResult.java
@@ -1,16 +1,14 @@
 package com.kilometer.domain.archive.queryDto;
 
 import com.kilometer.domain.archive.PlaceType;
-import com.kilometer.domain.archive.VisitedPlace;
+import com.kilometer.domain.archive.entity.VisitedPlace;
 import com.kilometer.domain.archive.dto.ArchiveInfo;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Getter
 @NoArgsConstructor

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/image/ImageService.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/image/ImageService.java
@@ -1,0 +1,18 @@
+package com.kilometer.domain.image;
+
+import com.kilometer.domain.util.S3Uploader;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final S3Uploader s3Uploader;
+
+    public String upload(MultipartFile file) throws IOException {
+        return s3Uploader.upload(file, "static");
+    }
+}

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/util/ApiUrlUtils.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/util/ApiUrlUtils.java
@@ -14,6 +14,8 @@ public class ApiUrlUtils {
 
     public static final String ARCHIVE_MY = "/my";
 
+    public static final String IMAGE_ROOT = ROOT + "/image";
+
     public static String getPickItemUrl(long itemId) {
         return String.format(PICK_ITEM_PATTERN + "?status=", itemId);
     }

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/util/S3Uploader.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/util/S3Uploader.java
@@ -1,0 +1,66 @@
+package com.kilometer.domain.util;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.platform.commons.util.Preconditions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    private final AmazonS3Client amazonS3Client;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String upload(MultipartFile multipartFile, String dirName) throws IOException {
+        Preconditions.notNull(multipartFile, "File must be not null.");
+        File uploadFile = convert(multipartFile)
+            .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File로 전환이 실패했습니다."));
+
+        return upload(uploadFile, dirName);
+    }
+
+    private String upload(File uploadFile, String dirName) {
+        String fileName = dirName + "/" + uploadFile.getName();
+        String uploadImageUrl = putS3(uploadFile, fileName);
+        removeNewFile(uploadFile);
+        return uploadImageUrl;
+    }
+
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(
+            CannedAccessControlList.PublicRead));
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("파일이 삭제되었습니다.");
+        } else {
+            log.info("파일이 삭제되지 못했습니다.");
+        }
+    }
+
+    private Optional<File> convert(MultipartFile file) throws IOException {
+        File convertFile = new File(file.getOriginalFilename());
+        if (convertFile.createNewFile()) {
+            try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+                fos.write(file.getBytes());
+            }
+            return Optional.of(convertFile);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/kilometer-backend-domain/src/main/resources/application.yml
+++ b/kilometer-backend-domain/src/main/resources/application.yml
@@ -21,9 +21,32 @@ spring:
         user_sql_comments: true
         format_sql: true
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
   flyway:
     enabled: true
     baseline-on-migrate: true
     baseline-version: 0
+
 logging:
   config: classpath:log4j2.xml
+  level:
+    com:
+      amazonaws:
+        util:
+          EC2MetadataUtils: error
+
+cloud:
+  aws:
+    s3:
+      bucket: kilometer-image
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    credentials:
+      accessKey: ${s3.accessKey}
+      secretKey: ${s3.secretKey}


### PR DESCRIPTION
ImageController를 통해 Image를 S3에 등록할 수 있습니다,
- 이 때 사진 파일 1개 당 1번의 Request를 요구합니다.
- List<MultipartFile> 형식으로 받을 수 있지만, 사용자 경험상 이미지 등록이 실패했을 경우 다시 모든 사진을 업로드 하는 것은 바람직 하지 않다고 판단하였습니다.
- Image는 등록만 할 수 있습니다. 삭제는 ArchivePhoto 테이블에서 지워지지만 S3에서 삭제되지는 않습니다. (추후 복구 요청 가능)

ArchiveService.save()에 ArchivePhoto 연관관계 로직이 추가되었습니다. 단순 등록만 가능한 상태입니다.
- cascade = CASCADETYPE.ALL 옵션으로 자동 등록하도록 해주었습니다. 

Archive update에 관해서 고려해야할 사항들이 있어서 별도 테스트 후 task 추가하도록 하겠습니다.