### PR TITLE
Kodo92/fix archive save

### DIFF
--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveAggregateConverter.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveAggregateConverter.java
@@ -11,6 +11,7 @@ import com.kilometer.domain.archive.userVisitPlace.UserVisitPlace;
 import com.kilometer.domain.badge.ItemBadge;
 import com.kilometer.domain.badge.ItemBadgeGenerator;
 import com.kilometer.domain.item.enumType.ExhibitionType;
+import com.kilometer.domain.user.dto.UserResponse;
 import com.kilometer.domain.util.ApiUrlUtils;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +61,29 @@ public class ArchiveAggregateConverter {
             .id(archive.getId())
             .userProfileUrl(archive.getUser().getImageUrl())
             .userName(archive.getUser().getName())
+            .updatedAt(archive.getUpdatedAt())
+            .starRating(archive.getStarRating())
+            .heartCount(archive.getLikeCount())
+            .heart(archiveHeart)
+            .comment(archive.getComment())
+            .food(placeTypes.getOrDefault(PlaceType.FOOD, ""))
+            .cafe(placeTypes.getOrDefault(PlaceType.CAFE, ""))
+            .photoUrls(archive.getArchiveImages().stream()
+                .map(ArchiveImage::getImageUrl)
+                .collect(Collectors.toList()))
+            .build();
+    }
+
+    public ArchiveInfo convertArchiveInfo(Archive archive, UserResponse userResponse) {
+
+        Map<PlaceType, String> placeTypes = convertFoodAndCafe(archive.getUserVisitPlaces());
+
+        ArchiveHeart archiveHeart = archiveHeartGenerator.generateArchiveHeart(archive.getId());
+
+        return ArchiveInfo.builder()
+            .id(archive.getId())
+            .userProfileUrl(userResponse.getImageUrl())
+            .userName(userResponse.getName())
             .updatedAt(archive.getUpdatedAt())
             .starRating(archive.getStarRating())
             .heartCount(archive.getLikeCount())

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveService.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveService.java
@@ -18,6 +18,8 @@ import com.kilometer.domain.paging.PagingStatusService;
 import com.kilometer.domain.paging.RequestPagingStatus;
 import com.kilometer.domain.paging.ResponsePagingStatus;
 import com.kilometer.domain.user.User;
+import com.kilometer.domain.user.UserService;
+import com.kilometer.domain.user.dto.UserResponse;
 import com.kilometer.domain.util.FrontUrlUtils;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ArchiveService {
 
+    private final UserService userService;
     private final ArchiveRepository archiveRepository;
     private final ArchiveImageService archiveImageService;
     private final UserVisitPlaceService userVisitPlaceService;
@@ -44,11 +47,14 @@ public class ArchiveService {
     public ArchiveInfo save(Long userId, ArchiveRequest archiveRequest) {
         validateArchiveRequest(archiveRequest, userId);
 
+        UserResponse userResponse = userService.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("잘못된 사용자 정보 입니다."));
+
         Archive archive = saveArchive(archiveRequest, userId, archiveRequest.getItemId());
         archiveImageService.saveAll(archiveRequest, archive);
         userVisitPlaceService.saveAll(archiveRequest, archive);
 
-        return archiveAggregateConverter.convertArchiveInfo(archive);
+        return archiveAggregateConverter.convertArchiveInfo(archive, userResponse);
     }
 
     @Transactional


### PR DESCRIPTION
#108 
아카이브 등록할 때 반환되는 데이터에 유저 정보 없는 문제 수정
1. Converter 오버로딩 추가

Service레벨에서 Transaction을 걸지 않고 Repository단위로 DB Transaction을 건다면 ArchiveService.save 함수 내부에서 Archive 엔티티에 User 데이터 추가하는 방법도 가능. (Transaction 범위가 아니기 때문에 Dirty checking 일어나지 않음)