### PR TITLE
Kodo92/hotfix archive detail is visible

### DIFF
--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveAggregateConverter.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveAggregateConverter.java
@@ -138,6 +138,7 @@ public class ArchiveAggregateConverter {
             .photoUrls(
                 archiveImages.stream().map(ArchiveImage::getImageUrl).collect(Collectors.toList()))
             .archiveAdditionalInfos(linkInfos)
+            .visibleAtItem(archiveDetailDto.isVisibleAtItem())
             .build();
     }
 

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepositoryCustomImpl.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepositoryCustomImpl.java
@@ -118,6 +118,7 @@ public class ArchiveRepositoryCustomImpl implements ArchiveRepositoryCustom {
                 itemEntity.title,
                 archive.comment,
                 archive.starRating,
+                archive.isVisibleAtItem,
                 user.id.eq(userId).as("isWrited")
             ))
             .from(archive)


### PR DESCRIPTION
/api/deail/{archiveId} 에서 노출 여부 누락되는 이슈 해결